### PR TITLE
Allow CORS wildcard for reset

### DIFF
--- a/auctioneer/ticker.go
+++ b/auctioneer/ticker.go
@@ -74,6 +74,7 @@ func readRequestBody(r *http.Request) (body []byte) {
 }
 
 func reset(a *appContext, c web.C, w http.ResponseWriter, r *http.Request) (int, error) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	a.reset <- true
 	return 200, nil
 }


### PR DESCRIPTION
Added a single line to allow for remote access in browsers to the reset API.
